### PR TITLE
支持多个Servant

### DIFF
--- a/examples/TarsActDemo/QD.ActCommentServer/src/component/Utils.php
+++ b/examples/TarsActDemo/QD.ActCommentServer/src/component/Utils.php
@@ -11,7 +11,7 @@ namespace Server\component;
 
 class Utils
 {
-    public static function objToArrayForTaf($obj)
+    public static function objToArrayForTars($obj)
     {
         $data = is_array($obj) ? $obj : get_object_vars($obj);
 
@@ -27,7 +27,7 @@ class Utils
             }
 
             if (is_array($value) || is_object($value)) {
-                $data[$key] = self::objToArrayForTaf($value);
+                $data[$key] = self::objToArrayForTars($value);
             }
         }
 

--- a/examples/TarsActDemo/QD.ActCommentServer/src/composer.json
+++ b/examples/TarsActDemo/QD.ActCommentServer/src/composer.json
@@ -2,7 +2,7 @@
     "name" : "tars-tcp-server-demo",
     "description": "tars tcp server",
     "require": {
-        "phptars/tars-server": "~0.2",
+        "phptars/tars-server": "~0.3",
         "phptars/tars-deploy": "~0.1",
         "phptars/tars-log": "~0.1",
         "phptars/tars2php": "~0.1",

--- a/examples/TarsActDemo/QD.ActCommentServer/src/service/CommentService.php
+++ b/examples/TarsActDemo/QD.ActCommentServer/src/service/CommentService.php
@@ -28,7 +28,7 @@ class CommentService
             $comment->userId = $inParam->userId;
         }
 
-        $commentArray = Utils::objToArrayForTaf($comment);
+        $commentArray = Utils::objToArrayForTars($comment);
 
         $redis->hMset(self::getCommentContext($id), $commentArray);
 

--- a/examples/TarsActDemo/QD.ActCommentServer/src/services.php
+++ b/examples/TarsActDemo/QD.ActCommentServer/src/services.php
@@ -7,7 +7,11 @@
  */
 
 // 以namespace的方式,在psr4的框架下对代码进行加载
-return array(
-    'home-api' => '\Server\protocol\QD\ActCommentServer\CommentObj\ActCommentServiceServant',
-    'home-class' => '\Server\impl\ActCommentServerImpl',
-);
+return [
+    'CommentObj' => [
+        'home-api' => '\Server\protocol\QD\ActCommentServer\CommentObj\ActCommentServiceServant',
+        'home-class' => '\Server\impl\ActCommentServerImpl',
+        'protocolName' => 'tars', //http, json, tars or other
+        'serverType' => 'tcp', //http(no_tars default), websocket, tcp(tars default), udp
+    ],
+];

--- a/examples/TarsActDemo/QD.ActHttpServer/README.md
+++ b/examples/TarsActDemo/QD.ActHttpServer/README.md
@@ -22,7 +22,9 @@
 
 ## 服务部署guideline
 
-1. 进入运维管理=> 模板管理
+~~1. 进入运维管理=> 模板管理~~ 
+(这一步不需要做了，0.3版本的tars-server， protocolName 在services.php中指定，请使用 tars.tarsphp.default 模板)
+
 平台会提供一份新的针对php的模板,命名为tars.tarsphp.default. 
 
 !!!!!!!必须首先修改其中php的执行路径!!!!!!!

--- a/examples/TarsActDemo/QD.ActHttpServer/src/composer.json
+++ b/examples/TarsActDemo/QD.ActHttpServer/src/composer.json
@@ -2,7 +2,7 @@
     "name" : "tars-http-server-demo",
     "description": "tars http server",
     "require": {
-        "phptars/tars-server": "~0.2",
+        "phptars/tars-server": "~0.3",
         "phptars/tars-deploy": "~0.1",
         "phptars/tars2php": "~0.1",
         "phptars/tars-log": "~0.1",

--- a/examples/TarsActDemo/QD.ActHttpServer/src/services.php
+++ b/examples/TarsActDemo/QD.ActHttpServer/src/services.php
@@ -7,20 +7,24 @@
  */
 
 // 以namespace的方式,在psr4的框架下对代码进行加载
-return array(
-    'namespaceName' => 'HttpServer\\',
-    'monitorStoreConf' => [
-        //使用redis缓存主调上报信息
-        //'className' => Tars\monitor\cache\RedisStoreCache::class,
-        //'config' => [
-        // 'host' => '127.0.0.1',
-        // 'port' => 6379,
-        // 'password' => ':'
-        //],
-        //使用swoole_table缓存主调上报信息（默认）
-        'className' => Tars\monitor\cache\SwooleTableStoreCache::class,
-        'config' => [
-            'size' => 40960
-        ]
-    ]
-);
+return [
+    'obj' => [
+        'namespaceName' => 'HttpServer\\',
+        'monitorStoreConf' => [
+            //使用redis缓存主调上报信息
+            //'className' => Tars\monitor\cache\RedisStoreCache::class,
+            //'config' => [
+            // 'host' => '127.0.0.1',
+            // 'port' => 6379,
+            // 'password' => ':'
+            //],
+            //使用swoole_table缓存主调上报信息（默认）
+            'className' => Tars\monitor\cache\SwooleTableStoreCache::class,
+            'config' => [
+                'size' => 40960
+            ]
+        ],
+        'protocolName' => 'http', //http, json, tars or other
+        'serverType' => 'http', //http(no_tars default), websocket, tcp(tars default), udp
+    ],
+];

--- a/examples/TarsActDemo/QD.UserService/src/App.php
+++ b/examples/TarsActDemo/QD.UserService/src/App.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: zhangyong
+ * Date: 2019/6/17
+ * Time: 15:43
+ */
+
+namespace Server;
+
+use MysqliDb;
+use Server\conf\ENVConf;
+
+class App
+{
+    public static $hasInitDb = false;
+
+    public static function initDb()
+    {
+        if (self::$hasInitDb) {
+            return true;
+        }
+
+        $dbsConf = ENVConf::getDbConf();
+        if (empty($dbsConf)) {
+            return false;
+        }
+
+        $db = new MysqliDb($dbsConf[0]);
+        foreach ($dbsConf as $config) {
+            $db->addConnection($config['instanceName'], $config);
+        }
+
+        self::$hasInitDb = true;
+    }
+}

--- a/examples/TarsActDemo/QD.UserService/src/component/BaseTrait.php
+++ b/examples/TarsActDemo/QD.UserService/src/component/BaseTrait.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: zhangyong
+ * Date: 2016/9/21
+ * Time: 14:10
+ */
+
+namespace Server\component;
+
+use HttpServer\conf\Code;
+use HttpServer\exception\ActivityException;
+
+trait BaseTrait
+{
+    public static function getController($throwException = true)
+    {
+        $id = \Swoole\Coroutine::getuid();
+        if (isset(BusinessController::$controller[$id])) {
+            return BusinessController::$controller[$id];
+        } else {
+            return null;
+        }
+    }
+
+    public static function getRequestData($key1 = null, $key2 = null, $default = null)
+    {
+        if (!self::getController(false)) {
+            return $default;
+        }
+
+        if ($key1 == null) {
+            return self::getController()->getRequest()->data;
+        }
+
+        if (!isset(self::getController()->getRequest()->data[$key1])) {
+            return $default;
+        }
+
+        if ($key2 == null) {
+            return self::getController()->getRequest()->data[$key1];
+        }
+
+        if (!isset(self::getController()->getRequest()->data[$key1][$key2])) {
+            return $default;
+        }
+
+        return self::getController()->getRequest()->data[$key1][$key2];
+    }
+
+    public static function getGet($key, $defaultVal = null)
+    {
+        $out = self::getRequestData('get', $key);
+
+        return $out === null ? $defaultVal : $out;
+    }
+
+    public static function getPost($key, $defaultVal = null)
+    {
+        if (isset(self::getController()->postData[$key])) {
+            return self::getController()->postData[$key];
+        } else {
+            return $defaultVal;
+        }
+    }
+
+    public static function getUserId()
+    {
+        $controller = self::getController();
+        if ($controller != null && $controller->session != null && $controller->session->isLogin) {
+            return $controller->session->userId;
+        } else {
+            return false;
+        }
+    }
+
+    public static function checkIsLogin($throwException = false)
+    {
+        $userId = self::getUserId();
+        if ($userId === false) {
+            if ($throwException) {
+                throw new ActivityException(Code::CODE_UNLOGIN);
+            } else {
+                return false;
+            }
+        } else {
+            return true;
+        }
+    }
+
+}

--- a/examples/TarsActDemo/QD.UserService/src/component/BusinessController.php
+++ b/examples/TarsActDemo/QD.UserService/src/component/BusinessController.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: liangchen
+ * Date: 2018/5/8
+ * Time: 下午2:43.
+ */
+
+namespace Server\component;
+
+use HttpServer\conf\Code;
+use Exception;
+use HttpServer\exception\ActivityException;
+use Server\App;
+use Tars\core\Request;
+use Tars\core\Response;
+use Swoole\Coroutine;
+
+class BusinessController extends Controller
+{
+    use BaseTrait;
+
+    public static $controller = [];
+
+    public $session = null;
+
+    protected $postData = null;
+
+    public function __construct(Request $request, Response $response)
+    {
+        parent::__construct($request, $response);
+        self::saveController($this);
+        App::initDb();
+        $this->processPost(true);
+    }
+
+    public function sendSuccess($data = [])
+    {
+        $ret = [
+            'code' => 0,
+            'msg' => 'success',
+            'data' => $data,
+        ];
+
+        $this->send($ret);
+    }
+
+    public function send($data)
+    {
+        self::unsetController();
+        $this->header('Content-Type', 'application/json');
+
+        if (!isset($data['code'])) {
+            $code = Code::CODE_FAIL;
+            $res = array('code' => $code, 'msg' => Code::getAjaxMsg($code));
+            $this->sendRaw(json_encode($res));
+            return;
+        } else {
+            $data['msg'] = isset($data['msg']) ? $data['msg'] : Code::getAjaxMsg($data['code']);
+            $data = json_encode($data);
+            $this->sendRaw($data);
+            return;
+        }
+    }
+
+    public function run($fun)
+    {
+        try {
+            $this->$fun();
+        } catch (\Exception $e) {
+            $this->sendByException($e);
+        }
+    }
+
+    protected function sendByException($e)
+    {
+        if (get_class($e) == ActivityException::class) {
+            $ret = [
+                'code' => $e->getCode(),
+                'msg' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(), //TODO only dev env
+            ];
+        } else {
+            $ret = [
+                'code' => Code::CODE_FAIL,
+                'msg' => "System error, check log file",
+            ];
+        }
+
+        $this->send($ret);
+    }
+
+    protected static function saveController($controller)
+    {
+        $id = Coroutine::getuid();
+        self::$controller[$id] = $controller;
+    }
+
+    protected static function unsetController()
+    {
+        $id = Coroutine::getuid();
+        unset(self::$controller[$id]);
+    }
+
+    protected function processPost($force = false)
+    {
+        if ($this->postData === null || $force) {
+            if (isset($this->request->data['header']['content-type']) && strpos($this->request->data['header']['content-type'], 'json') !== false) {
+                $this->postData = json_decode($this->request->data['post'], true);
+            } else {
+                $this->postData = $this->request->data['post'];
+            }
+        }
+    }
+}

--- a/examples/TarsActDemo/QD.UserService/src/component/Controller.php
+++ b/examples/TarsActDemo/QD.UserService/src/component/Controller.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: liangchen
+ * Date: 2018/5/8
+ * Time: 下午2:43.
+ */
+
+namespace Server\component;
+
+use Tars\core\Request;
+use Tars\core\Response;
+
+class Controller
+{
+    protected $request;
+    protected $response;
+
+    public function __construct(Request $request, Response $response)
+    {
+        // 验证cookie、get参数、post参数、文件上传
+
+        $this->request = $request;
+        $this->response = $response;
+    }
+
+    public function getResponse()
+    {
+        return $this->response;
+    }
+
+    public function getRequest()
+    {
+        return $this->request;
+    }
+
+    public function cookie($key, $value = '', $expire = 0, $path = '/', $domain = '', $secure = false, $httponly = false)
+    {
+        $this->response->cookie($key, $value, $expire, $path, $domain, $secure, $httponly);
+    }
+
+    // 给客户端发送数据
+    public function sendRaw($result)
+    {
+        $this->response->send($result);
+    }
+
+    public function header($key, $value)
+    {
+        $this->response->header($key, $value);
+    }
+
+    public function status($http_status_code)
+    {
+        $this->response->status($http_status_code);
+    }
+}

--- a/examples/TarsActDemo/QD.UserService/src/component/Utils.php
+++ b/examples/TarsActDemo/QD.UserService/src/component/Utils.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: zhangyong
+ * Date: 2018/8/17
+ * Time: 17:26
+ */
+
+namespace Server\component;
+
+
+class Utils
+{
+    public static function objToArrayForTars($obj)
+    {
+        $data = is_array($obj) ? $obj : get_object_vars($obj);
+
+        foreach ($data as $key => $value) {
+            if ($key === '__fields' || $key === '__typeName') {
+                unset($data[$key]);
+                continue;
+            }
+
+            if ($value === null) {
+                unset($data[$key]);
+                continue;
+            }
+
+            if (is_array($value) || is_object($value)) {
+                $data[$key] = self::objToArrayForTars($value);
+            }
+        }
+
+        return $data;
+    }
+}

--- a/examples/TarsActDemo/QD.UserService/src/composer.json
+++ b/examples/TarsActDemo/QD.UserService/src/composer.json
@@ -2,7 +2,7 @@
     "name" : "tars-tcp-server-demo",
     "description": "tars tcp server",
     "require": {
-        "phptars/tars-server": "~0.2",
+        "phptars/tars-server": "~0.3",
         "phptars/tars-deploy": "~0.1",
         "phptars/tars-log": "~0.1",
         "phptars/tars2php": "~0.1",

--- a/examples/TarsActDemo/QD.UserService/src/controller/UserController.php
+++ b/examples/TarsActDemo/QD.UserService/src/controller/UserController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Server\controller;
+
+use Server\component\BusinessController;
+use Server\component\Utils;
+use Server\service\UserInfoService;
+
+use \Server\protocol\QD\UserService\UserObj\classes\User;
+
+class UserController extends BusinessController
+{
+    public function actionIndex()
+    {
+        $this->sendSuccess('hello word');
+    }
+
+    public function actionGetUsersInfoByIds()
+    {
+        $ids = self::getGet('ids');
+        $usersId = explode(',', $ids);
+
+        $info = new \TARS_Map(\TARS::INT64, new User);
+        UserInfoService::getUserInfoByIds($usersId, $info, $outArray);
+
+        $this->sendSuccess(Utils::objToArrayForTars($outArray));
+    }
+}

--- a/examples/TarsActDemo/QD.UserService/src/impl/UserServiceImpl.php
+++ b/examples/TarsActDemo/QD.UserService/src/impl/UserServiceImpl.php
@@ -9,9 +9,8 @@
 namespace Server\impl;
 
 
-use MysqliDb;
+use Server\App;
 use Server\conf\Code;
-use Server\conf\ENVConf;
 use Server\exception\BusinessException;
 use Server\protocol\QD\UserService\UserObj\classes\CommonInParam;
 use Server\protocol\QD\UserService\UserObj\classes\CommonOutParam;
@@ -22,11 +21,7 @@ class UserServiceImpl implements UserServiceServant
 {
     public function __construct()
     {
-        $dbsConf = ENVConf::getDbConf();
-        $db = new MysqliDb($dbsConf[0]);
-        foreach ($dbsConf as $config) {
-            $db->addConnection($config['instanceName'], $config);
-        }
+        App::initDb();
     }
 
     /**

--- a/examples/TarsActDemo/QD.UserService/src/service/UserInfoService.php
+++ b/examples/TarsActDemo/QD.UserService/src/service/UserInfoService.php
@@ -15,7 +15,7 @@ use Server\protocol\QD\UserService\UserObj\classes\User;
 
 class UserInfoService
 {
-    public static function getUserInfoByIds($usersId, &$info)
+    public static function getUserInfoByIds($usersId, &$info, &$outArray = null)
     {
         if (empty($usersId)) {
             return;
@@ -39,6 +39,7 @@ class UserInfoService
                 $tmp->nickname = $usersObjWithIndex[$userId]->nickname;
                 $tmp->avatar = $usersObjWithIndex[$userId]->avatar;
                 $tmp->createTime = strtotime($usersObjWithIndex[$userId]->createTime);
+                $outArray[] = $tmp;
                 $info->pushBack([$userId => $tmp]);
             }
         }

--- a/examples/TarsActDemo/QD.UserService/src/services.php
+++ b/examples/TarsActDemo/QD.UserService/src/services.php
@@ -7,7 +7,30 @@
  */
 
 // 以namespace的方式,在psr4的框架下对代码进行加载
-return array(
-    'home-api' => 'Server\protocol\QD\UserService\UserObj\UserServiceServant',
-    'home-class' => '\Server\impl\UserServiceImpl',
-);
+return [
+    'HttpObj' => [
+        'namespaceName' => 'Server\\',
+        'monitorStoreConf' => [
+            //使用redis缓存主调上报信息
+            //'className' => Tars\monitor\cache\RedisStoreCache::class,
+            //'config' => [
+            // 'host' => '127.0.0.1',
+            // 'port' => 6379,
+            // 'password' => ':'
+            //],
+            //使用swoole_table缓存主调上报信息（默认）
+            'className' => Tars\monitor\cache\SwooleTableStoreCache::class,
+            'config' => [
+                'size' => 40960
+            ]
+        ],
+        'protocolName' => 'http', //http, json, tars or other
+        'serverType' => 'http', //http(no_tars default), webSocket, tcp(tars default), udp
+    ],
+    'UserObj' => [
+        'home-api' => 'Server\protocol\QD\UserService\UserObj\UserServiceServant',
+        'home-class' => '\Server\impl\UserServiceImpl',
+        'protocolName' => 'tars', //http, json, tars or other
+        'serverType' => 'tcp', //http(no_tars default), webSocket, tcp(tars default), udp
+    ],
+];

--- a/examples/TarsActDemo/QD.UserService/src/services.php
+++ b/examples/TarsActDemo/QD.UserService/src/services.php
@@ -31,6 +31,6 @@ return [
         'home-api' => 'Server\protocol\QD\UserService\UserObj\UserServiceServant',
         'home-class' => '\Server\impl\UserServiceImpl',
         'protocolName' => 'tars', //http, json, tars or other
-        'serverType' => 'tcp', //http(no_tars default), webSocket, tcp(tars default), udp
+        'serverType' => 'tcp', //http(no_tars default), websocket, tcp(tars default), udp
     ],
 ];

--- a/examples/tars-http-server/README.md
+++ b/examples/tars-http-server/README.md
@@ -22,7 +22,9 @@
 
 ## 服务部署guideline
 
-1. 进入运维管理=> 模板管理
+~~1. 进入运维管理=> 模板管理~~ 
+(这一步不需要做了，0.3版本的tars-server， protocolName 在services.php中指定，请使用 tars.tarsphp.default 模板)
+
 平台会提供一份新的针对php的模板,命名为tars.tarsphp.default. 
 
 !!!!!!!必须首先修改其中php的执行路径!!!!!!!

--- a/examples/tars-http-server/src/composer.json
+++ b/examples/tars-http-server/src/composer.json
@@ -2,7 +2,7 @@
     "name" : "tars-http-server-demo",
     "description": "tars http server",
     "require": {
-        "phptars/tars-server": "~0.2",
+        "phptars/tars-server": "~0.3",
         "phptars/tars-deploy": "~0.1",
         "phptars/tars2php": "~0.1",
         "phptars/tars-log": "~0.1",

--- a/examples/tars-http-server/src/services.php
+++ b/examples/tars-http-server/src/services.php
@@ -7,28 +7,32 @@
  */
 
 // 以namespace的方式,在psr4的框架下对代码进行加载
-return array(
-    'namespaceName' => 'HttpServer\\',
-    'saveTarsConfigFileDir' => 'src/conf/', //从tarsconfig拉下来的文件保存目录 默认src目录下的conf
-    'saveTarsConfigFileName' => [ '',], //需要从tarsconfig拉下来的文件名 在web上配置
-    'monitorStoreConf' => [
-        //使用redis缓存主调上报信息
-        //'className' => Tars\monitor\cache\RedisStoreCache::class,
-        //'config' => [
-        // 'host' => '127.0.0.1',
-        // 'port' => 6379,
-        // 'password' => ':'
-        //],
-        //使用swoole_table缓存主调上报信息（默认）
-        'className' => Tars\monitor\cache\SwooleTableStoreCache::class,
-        'config' => [
-            'size' => 40960
-        ]
+return [
+    'obj' => [
+        'namespaceName' => 'HttpServer\\',
+        'saveTarsConfigFileDir' => 'src/conf/', //从tarsconfig拉下来的文件保存目录 默认src目录下的conf
+        'saveTarsConfigFileName' => [ '',], //需要从tarsconfig拉下来的文件名 在web上配置
+        'monitorStoreConf' => [
+            //使用redis缓存主调上报信息
+            //'className' => Tars\monitor\cache\RedisStoreCache::class,
+            //'config' => [
+            // 'host' => '127.0.0.1',
+            // 'port' => 6379,
+            // 'password' => ':'
+            //],
+            //使用swoole_table缓存主调上报信息（默认）
+            'className' => Tars\monitor\cache\SwooleTableStoreCache::class,
+            'config' => [
+                'size' => 40960
+            ]
+        ],
+        'registryStoreConf' => [
+            'className' => Tars\registry\RouteTable::class,
+            'config' => [
+                'size' => 200
+            ]
+        ],
+        'protocolName' => 'http', //http, json, tars or other
+        'serverType' => 'http', //http(no_tars default), websocket, tcp(tars default), udp
     ],
-    'registryStoreConf' => [
-        'className' => Tars\registry\RouteTable::class,
-        'config' => [
-            'size' => 200
-        ]
-    ]
-);
+];

--- a/examples/tars-tcp-server/src/composer.json
+++ b/examples/tars-tcp-server/src/composer.json
@@ -2,7 +2,7 @@
     "name" : "tars-tcp-server-demo",
     "description": "tars tcp server",
     "require": {
-        "phptars/tars-server": "~0.2",
+        "phptars/tars-server": "~0.3",
         "phptars/tars-deploy": "~0.1",
         "phptars/tars-log": "~0.1",
         "phptars/tars2php": "~0.1",

--- a/examples/tars-tcp-server/src/services.php
+++ b/examples/tars-tcp-server/src/services.php
@@ -7,7 +7,11 @@
  */
 
 // 以namespace的方式,在psr4的框架下对代码进行加载
-return array(
-    'home-api' => '\Server\servant\PHPTest\PHPServer\obj\TestTafServiceServant',
-    'home-class' => '\Server\impl\PHPServerServantImpl',
-);
+return [
+    'obj' => [
+        'home-api' => '\Server\servant\PHPTest\PHPServer\obj\TestTafServiceServant',
+        'home-class' => '\Server\impl\PHPServerServantImpl',
+        'protocolName' => 'tars', //http, json, tars or other
+        'serverType' => 'tcp', //http(no_tars default), websocket, tcp(tars default), udp
+    ],
+];

--- a/examples/tars-timer-server/README.md
+++ b/examples/tars-timer-server/README.md
@@ -2,7 +2,9 @@
 
 ## 服务部署guideline
 
-1. 进入运维管理 => 模板管理
+~~1. 进入运维管理=> 模板管理~~ 
+(这一步不需要做了，0.3版本的tars-server， isTimer 在services.php中指定，请使用 tars.tarsphp.default 模板)
+
 
 平台会提供一份新的针对php的模板,命名为tars.tarsphp.default, !!!!!!!必须首先修改其中php的执行路径!!!!!!!
  

--- a/examples/tars-timer-server/src/composer.json
+++ b/examples/tars-timer-server/src/composer.json
@@ -2,7 +2,7 @@
     "name" : "tars-timer-server-demo",
     "description": "tars timer server",
     "require": {
-        "phptars/tars-server": "~0.2",
+        "phptars/tars-server": "~0.3",
         "phptars/tars-deploy": "~0.1",
         "phptars/tars2php": "~0.1",
         "ext-zip" : ">=0.0.1"

--- a/examples/tars-timer-server/src/services.php
+++ b/examples/tars-timer-server/src/services.php
@@ -8,5 +8,8 @@
 
 // 以namespace的方式,在psr4的框架下对代码进行加载
 return array(
-    'namespaceName' => 'TimerServer\\',
+    'obj' => array(
+        'namespaceName' => 'TimerServer\\',
+        'isTimer' => true,
+    ),
 );

--- a/examples/tars-websocket-server/README.md
+++ b/examples/tars-websocket-server/README.md
@@ -22,7 +22,9 @@
 
 ## 服务部署guideline
 
-1. 进入运维管理=> 模板管理
+~~1. 进入运维管理=> 模板管理~~
+(这一步不需要做了，0.3版本的tars-server， protocolName 在services.php中指定，请使用 tars.tarsphp.default 模板)
+
 平台会提供一份新的针对php的模板,命名为tars.tarsphp.default. 
 
 !!!!!!!必须首先修改其中php的执行路径!!!!!!!

--- a/examples/tars-websocket-server/src/composer.json
+++ b/examples/tars-websocket-server/src/composer.json
@@ -2,7 +2,7 @@
     "name" : "tars-websocket-server-demo",
     "description": "tars websocket server",
     "require": {
-        "phptars/tars-server": "~0.2",
+        "phptars/tars-server": "~0.3.1",
         "phptars/tars-deploy": "~0.1",
         "phptars/tars2php": "~0.1",
         "phptars/tars-log": "~0.1",

--- a/examples/tars-websocket-server/src/services.php
+++ b/examples/tars-websocket-server/src/services.php
@@ -7,23 +7,27 @@
  */
 
 // 以namespace的方式,在psr4的框架下对代码进行加载
-return array(
-    'namespaceName' => 'WebsocketServer\\',
-    'home-class' => '\WebsocketServer\message\ExampleWebsocket',
-    'saveTarsConfigFileDir' => 'src/conf/', //从tarsconfig拉下来的文件保存目录 默认src目录下的conf
-    'saveTarsConfigFileName' => [ '',], //需要从tarsconfig拉下来的文件名 在web上配置
-    'monitorStoreConf' => [
-        //使用redis缓存主调上报信息
-        //'className' => Tars\monitor\cache\RedisStoreCache::class,
-        //'config' => [
-        // 'host' => '127.0.0.1',
-        // 'port' => 6379,
-        // 'password' => ':'
-        //],
-        //使用swoole_table缓存主调上报信息（默认）
-        'className' => Tars\monitor\cache\SwooleTableStoreCache::class,
-        'config' => [
-            'size' => 40960
-        ]
+return [
+    'obj' => [
+        'namespaceName' => 'WebsocketServer\\',
+        'home-class' => '\WebsocketServer\message\ExampleWebsocket',
+        'saveTarsConfigFileDir' => 'src/conf/', //从tarsconfig拉下来的文件保存目录 默认src目录下的conf
+        'saveTarsConfigFileName' => ['',], //需要从tarsconfig拉下来的文件名 在web上配置
+        'monitorStoreConf' => [
+            //使用redis缓存主调上报信息
+            //'className' => Tars\monitor\cache\RedisStoreCache::class,
+            //'config' => [
+            // 'host' => '127.0.0.1',
+            // 'port' => 6379,
+            // 'password' => ':'
+            //],
+            //使用swoole_table缓存主调上报信息（默认）
+            'className' => Tars\monitor\cache\SwooleTableStoreCache::class,
+            'config' => [
+                'size' => 40960
+            ]
+        ],
+        'protocolName' => 'http', //http, json, tars or other
+        'serverType' => 'websocket', //http(no_tars default), websocket, tcp(tars default), udp
     ]
-);
+];


### PR DESCRIPTION
支持多个servant
1. 使用swoole addListener 做底层支持
2. 支持一个服务部署多个obj，分别使用tars 或 http 协议
3. services.php 格式调整，返回以objName 为key 的二维数组。
4.  protocolName, serverType, isTimer 不在从私有模板中读取，需要在services.php中指定
5. demo见TarsActDemo下的QD.UserService 服务（timer见tars-timer-server服务）。